### PR TITLE
Update to Python 3.12.X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ axe-reports
 axe_reports
 sitemaps
 audits
+
+# .tool-versions
+.tool-versions

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ Ann Arbor will also show which templates of your site have the most errors, allo
 
 
 ## Environment
-- Python = 3.6.0
-- The site crawler, Scrapy, currently will not support Python versions above 3.6, so sitemap generation and full site audits rely on using this version of Python.
+- Python = 3.12.5
 
 
 ## Setup
@@ -16,9 +15,9 @@ This setup guide uses Pyenv as the python version manager and uses Chromedriver 
 - [Install Pyenv](https://github.com/pyenv/pyenv#installation)
 - [Install Chromedriver](https://chromedriver.chromium.org/getting-started)
 
-- Use pyenv to install Python 3.6.x
+- Use pyenv to install Python 3.12.x
 
-      pyenv install 3.6.x
+      pyenv install 3.12.x
 
 - Clone repository:
 
@@ -27,7 +26,7 @@ This setup guide uses Pyenv as the python version manager and uses Chromedriver 
 
 - Set local Python version:
 
-      pyenv local 3.6.0
+      pyenv local 3.12.0
 
 - Install dependencies:
 

--- a/models/axe_audit.py
+++ b/models/axe_audit.py
@@ -299,12 +299,8 @@ class AxePageAudit(AxeAudit):
         chrome_options = chrome.options.Options()
         chrome_options.add_argument("--headless")
 
-        # Use webdriver_manager to deal with version issues:
-        # https://github.com/formulafolios/ann-arbor/issues/2
-        driver_manager = ChromeDriverManager().install()
-
         # Set up Axe with Chrome driver
-        driver = webdriver.Chrome(driver_manager, chrome_options=chrome_options)
+        driver = webdriver.Chrome(options=chrome_options)
         driver.get(self.url)
         axe = Axe(driver)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 #
 # See README for more information on setup.
 #
-cement==3.0.0
+cement
 jinja2
 pyyaml
 colorlog


### PR DESCRIPTION
Python 3.6.16 was the final security update September 5, 2021.

This PR is to update to at least Python 3.12.X which should last until about October 2028.

I also allow cement to update to version 3.1.0 as 3.0.0 uses outdated packages from 3.6 which no longer exists. ChromeDriver needed an update to support 3.12.X as well.